### PR TITLE
Deploy pages to master, serve from there

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,6 +28,6 @@ jobs:
       - deploy:
           name: Maybe Deploy
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ "${CIRCLE_BRANCH}" == "develop" ]; then
               ./scripts/deploy-ghpages.sh
             fi

--- a/scripts/deploy-ghpages.sh
+++ b/scripts/deploy-ghpages.sh
@@ -22,14 +22,14 @@ git remote add --fetch origin "$remote"
 
 
 # switch into the the gh-pages branch
-if git rev-parse --verify origin/gh-pages > /dev/null 2>&1
+if git rev-parse --verify origin/master > /dev/null 2>&1
 then
-    git checkout gh-pages
+    git checkout master
     # delete any old site as we are going to replace it
     # Note: this explodes if there aren't any, so moving it here for now
     git rm -rf .
 else
-    git checkout --orphan gh-pages
+    git checkout --orphan master
 fi
 
 # copy over or recompile the new site
@@ -40,7 +40,7 @@ git add -A
 # now commit, ignoring branch gh-pages doesn't seem to work, so trying skip
 git commit --allow-empty -m "Deploy to GitHub pages [ci skip]"
 # and push, but send any output to /dev/null to hide anything sensitive
-git push --force --quiet origin gh-pages
+git push --force --quiet origin master
 # go back to where we started and remove the gh-pages git repo we made and used
 # for deployment
 cd ..


### PR DESCRIPTION
There is a restriction on this repo that gh pages can only be served from master. Changed default branch to `develop` and the script forcefully pushes to master now.