### PR TITLE
Deleted the 3 => three in the map example

### DIFF
--- a/source/guides/elixir-beginners-guide.html.erb
+++ b/source/guides/elixir-beginners-guide.html.erb
@@ -206,7 +206,7 @@ iex(4)> [{"eggs", {1, :dozen}}, {"milk", {2, :litre}}, {"freddo", 77}]
   Maps are data structures that allow you to assign a value to a key, so that given a key and a map, you can find the matching value. They are represent by braces, with a leading <code>%</code>, with key-value pairs listed inside:
   <pre>
 iex(1)> number_words = %{1 => "one", 2 => "two"}
-%{1 => "one", 2 => "two", 3 => "three"}
+%{1 => "one", 2 => "two"}
 iex(2)> number_words[1]
 "one"
 iex(3)> number_words[2]
@@ -311,4 +311,3 @@ iex(1)> "This is the value of our first variable" |> String.length() |> Kernel.d
 <p>
   Now that you have a taste of elixir, it's time to head on to try out our other <a class="inline-link" href="/guides/">guides</a>! Of course, you should continue to experiment with these Elixir basics, and be sure to ask a mentor for answers to any questions you may have, or for further information on anything you've seen in this guide. Have fun!
 </p>
-


### PR DESCRIPTION
There was an extra 3 in the result that didn't need to be there.