### PR TITLE
Update Phoenix installation command

### DIFF
--- a/source/install-guides/linux.html.erb
+++ b/source/install-guides/linux.html.erb
@@ -95,7 +95,7 @@ mix local.hex
   Now that we have Hex installed we can install Phoenix
 </p>
 <% code("bash") do %>
-mix archive.install https://github.com/phoenixframework/archives/raw/master/phoenix_new.ez
+mix archive.install hex phx_new 1.4.10
 <% end %>
 
 <p>If you haven't coded before you will want to take a look at <a class="inline-link" href="/install-guides/dev-tools.html">additional tools</a> for some extra tools that will help you get started otherwise we're good to go! Let's go write some elixir!</p>

--- a/source/install-guides/mac.html.erb
+++ b/source/install-guides/mac.html.erb
@@ -72,6 +72,6 @@ mix local.hex
 <% end %>
 <p>Now that we have Hex installed we can install Phoenix</p>
 <% code("bash") do %>
-mix archive.install https://github.com/phoenixframework/archives/raw/master/phoenix_new.ez
+mix archive.install hex phx_new 1.4.10
 <% end %>
 <p>If you haven't coded before you will want to take a look at <a class="inline-link" href="/install-guides/dev-tools.html">additional tools</a> for some extra tools that will help you get started otherwise we're good to go! Let's go write some elixir!</p>

--- a/source/install-guides/windows.html.erb
+++ b/source/install-guides/windows.html.erb
@@ -29,7 +29,7 @@ mix local.hex
 <% end %>
 <p>Now that we have Hex installed we can install Phoenix</p>
 <% code("bash") do %>
-mix archive.install https://github.com/phoenixframework/archives/raw/master/phoenix_new.ez
+mix archive.install hex phx_new 1.4.10
 <% end %>
 
 


### PR DESCRIPTION
The old command would install the old task `phoenix.new`, but the tutorial mentions the new task `phx.new`.

I wasn't sure if I should add a note so that people should check on https://hex.pm/packages/phx_new what is the current version of phx_new, or if we should just keep the version in the instructions up to date because that would be less confusing for total beginners.